### PR TITLE
Add changelogUrl for VCC

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "name": "Poiyomi",
     "url": "https://github.com/poiyomi/PoiyomiToonShader"
   },
+  "changelogUrl": "https://www.poiyomi.com/changelog",
   "gitDependencies": {},
   "vpmDependencies": {},
   "legacyFolders": {


### PR DESCRIPTION
Allows VCC applications to display a "Changelog" button link when installing package to Project, linking to the /changelog page on the Documentation.

This was highly requested by some of our community members and believe this would be useful.